### PR TITLE
fix for flask experiment

### DIFF
--- a/flask_experiment/cache.py
+++ b/flask_experiment/cache.py
@@ -4,9 +4,15 @@ from jinja2.utils import LRUCache
 
 class ExperimentTemplateCache(LRUCache):
     def experiment_key(self, key):
+        # newer versions of jinja pass this key as a tuple,
+        # but we want the name of the jinja file, which
+        # is the last item in the tuple
+        if key and isinstance(key, tuple):
+            key = key[-1]
+
         if request.exp_enabled:
             key = ":".join(["{}:{}".format(
-                exp.name, var.name) for exp, var in request.experiments.iteritems()]) + ":" + key
+                exp.name, var.name) for exp, var in request.experiments.items()]) + ":" + key
 
         return key
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==0.9
-Jinja2==2.6
-Werkzeug==0.8.3
+Flask==0.10.1
+Jinja2==2.9.4
+Werkzeug==0.9.6
 setuptools==1.0
 wsgiref==0.1.2


### PR DESCRIPTION
Trying to upgrade us to Jinja==2.9.4 created a conflict with the way flask-experiment keys off of jinja template names. This should resolve the problem, regardless of whether we use the old or new jinja versions